### PR TITLE
Do not produce a HA policy config when $ha_policy is unset

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -430,9 +430,11 @@ Default value: ``undef``
 
 ##### `ha_policy`
 
-Data type: `Enum['live-only','replication','shared-storage']`
+Data type: `Optional[Enum['live-only','replication','shared-storage']]`
 
 ActiveMQ Artemis HA policy.
+
+Default value: ``undef``
 
 ##### `initial_replication_sync_timeout`
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -135,7 +135,6 @@ define activemq::instance (
   Hash[String[1], Hash] $connectors,
   Array $discovery_groups,
   Boolean $failover_on_shutdown,
-  Enum['live-only','replication','shared-storage'] $ha_policy,
   Integer $initial_replication_sync_timeout,
   Integer $journal_buffer_timeout,
   Boolean $journal_datasync,
@@ -162,6 +161,7 @@ define activemq::instance (
   Optional[Boolean] $service_enable = undef,
   Optional[Enum['running','stopped']] $service_ensure = undef,
   Optional[String] $target_host = undef,
+  Optional[Enum['live-only','replication','shared-storage']] $ha_policy,
   # TODO: broker-plugins (nothing set by default, but it should be supported)
 ) {
   File {

--- a/templates/broker.xml.epp
+++ b/templates/broker.xml.epp
@@ -157,33 +157,37 @@ under the License.
          </cluster-connection>
       </cluster-connections>
 
+<%   if $ha_policy { -%>
       <ha-policy>
          <<%= $ha_policy %>>
+<%     if $ha_policy == 'replication' or $ha_policy == 'shared-storage' { -%>
             <<%= $role %>>
-<%   if !empty($group) { -%>
+<%       if !empty($group) { -%>
                <group-name><%= $group %></group-name>
-<%   } -%>
+<%       } -%>
                <cluster-name><%= $activemq::cluster_name %></cluster-name>
-<%   if $ha_policy == 'replication' { -%>
+<%       if $ha_policy == 'replication' { -%>
                <initial-replication-sync-timeout><%= $initial_replication_sync_timeout %></initial-replication-sync-timeout>
-<%     if $check_for_live_server and $role == 'master' { -%>
+<%         if $check_for_live_server and $role == 'master' { -%>
                <check-for-live-server>true</check-for-live-server>
-<%     } -%>
-<%     if $vote_on_replication_failure and $role == 'master' { -%>
+<%         } -%>
+<%         if $vote_on_replication_failure and $role == 'master' { -%>
                <vote-on-replication-failure>true</vote-on-replication-failure>
-<%     } -%>
-<%   } -%>
-<%   if $ha_policy == 'shared-storage' { -%>
-<%     if $failover_on_shutdown and $role == 'master' { -%>
+<%         } -%>
+<%       } -%>
+<%       if $ha_policy == 'shared-storage' { -%>
+<%         if $failover_on_shutdown and $role == 'master' { -%>
                <failover-on-shutdown>true</failover-on-shutdown>
-<%     } -%>
-<%   } -%>
-<%   if $allow_failback and $role == 'slave' { -%>
+<%         } -%>
+<%       } -%>
+<%       if $allow_failback and $role == 'slave' { -%>
                <allow-failback>true</allow-failback>
-<%   } -%>
+<%       } -%>
             </<%= $role %>>
+<%     } -%>
          </<%= $ha_policy %>>
       </ha-policy>
+<%   } -%>
 <% } -%>
 
 <%   if (('enable' in $security) and ($security['enable'] == true)) { -%>


### PR DESCRIPTION
Doing so will create a clustered server using the default HA policy which is a ["live only"](https://activemq.apache.org/components/artemis/documentation/latest/ha.html) cluster configuration which does not feature replication of persistent data.

This resolves part of issue #4. 

When ha_policy is `undef` no `<ha-policy>` entry is created, when it is set to `live-only` it will produce `<ha-policy><live-only></live-only></ha-policy>`. Both result in the same effective configuration.

There is no support for configuring the [scale-down](https://activemq.apache.org/components/artemis/documentation/latest/ha.html#scaling-down)