### PR TITLE
pdksync - update os support and workflow/testing environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         puppet_version: [7]
 
     name: Check / Puppet ${{ matrix.puppet_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: puppet/pdk:latest
 
     steps:
@@ -39,11 +39,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['rocky8', 'ub2204', 'deb11']
+        os: ['rocky8', 'ub2004', 'ub2204', 'ub2404', 'deb11', 'deb12']
         puppet_version: [7]
 
     name: Acceptance / ${{ matrix.os }} / Puppet ${{ matrix.puppet_version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs:
       - check
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -134,7 +134,7 @@ activemq::instance_defaults:
       # An optional wildcard that will be used when adding the address settings.
       wildcard: '#'
   allow_failback: true
-  bind: '%{fqdn}'
+  bind: '%{facts.networking.fqdn}'
   broadcast_groups:
     - name: 'bg-group1'
       group_address: '231.7.7.7'

--- a/metadata.json
+++ b/metadata.json
@@ -41,14 +41,16 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+        "12"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "20.04",
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,24 +1,24 @@
 ---
 default:
   provisioner: docker_exp
-  images: ['waffleimage/centos7']
+  images: ['litmusimage/rockylinux:8']
 vagrant:
   provisioner: vagrant
-  images: ['centos/7', 'generic/ubuntu2004']
+  images: ['centos/8', 'generic/ubuntu2404']
 
 deb_all:
   provisioner: docker
-  images: ['litmusimage/debian:10', 'litmusimage/debian:11']
+  images: ['litmusimage/debian:11', 'litmusimage/debian:12']
 el_all:
   provisioner: docker
-  images: ['litmusimage/centos:7', 'litmusimage/centos:8']
+  images: ['litmusimage/centos:7', 'litmusimage/rockylinux:8']
   # The most reliable workaround for the docker/systemd incompatibility.
   # see https://github.com/docker/for-linux/issues/835
   # see https://github.com/moby/moby/issues/38749
   vars: '{docker_run_opts: ["-v /sys/fs/cgroup:/sys/fs/cgroup:ro"]}'
 ub_all:
   provisioner: docker
-  images: ['litmusimage/ubuntu:20.04', 'litmusimage/ubuntu:22.04']
+  images: ['litmusimage/ubuntu:20.04', 'litmusimage/ubuntu:22.04', 'litmusimage/ubuntu:24.04']
 
 gha_deb10:
   provisioner: docker
@@ -26,6 +26,9 @@ gha_deb10:
 gha_deb11:
   provisioner: docker
   images: ['litmusimage/debian:11']
+gha_deb12:
+  provisioner: docker
+  images: ['litmusimage/debian:12']
 gha_el7:
   provisioner: docker
   images: ['litmusimage/centos:7']
@@ -53,3 +56,6 @@ gha_ub2004:
 gha_ub2204:
   provisioner: docker
   images: ['litmusimage/ubuntu:22.04']
+gha_ub2404:
+  provisioner: docker
+  images: ['litmusimage/ubuntu:24.04']


### PR DESCRIPTION
update os support and workflow/testing environment
pdk version: `3.2.0` 
